### PR TITLE
Django18 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url=http://dist.pinaxproject.com/dev/
 --extra-index-url=http://dist.pinaxproject.com/alpha/
 
-Django==1.7.11
+Django<1.9
 django-extensions
 pinax-theme-bootstrap==2.0.4
 pinax-theme-bootstrap-account==1.0b2


### PR DESCRIPTION
Written as "Django<1.9" as it uses the last 1.8.X version available, currently 1.8.13 but it can be higher in next months or years.