### PR TITLE
First changes to agent api

### DIFF
--- a/valuenetwork/api/schema.py
+++ b/valuenetwork/api/schema.py
@@ -13,12 +13,12 @@ from graphene_django.debug import DjangoDebug
 from django.conf import settings
 
 import valuenetwork.api.schemas.Auth
-import valuenetwork.api.schemas.EconomicAgent
+import valuenetwork.api.schemas.Agent
 from valuenetwork.api.schemas.helpers import hash_password
 
 
 class ViewerQuery(
-    valuenetwork.api.schemas.EconomicAgent.Query,
+    valuenetwork.api.schemas.Agent.Query,
     graphene.ObjectType
 ):
     def __init__(self, *args, **kwargs):

--- a/valuenetwork/api/schemas/Agent.py
+++ b/valuenetwork/api/schemas/Agent.py
@@ -36,16 +36,19 @@ class Query(graphene.AbstractType):
 
     # load single agents
 
+    def _load_own_agent(self):
+        agentUser = AgentUser.objects.filter(user=self.user).first()
+        if agentUser is None:
+            raise PermissionDenied("Cannot find requested user")
+        return agentUser.agent
+
     def resolve_agent(self, args, *rargs):
         me = args.get('me')
 
         # load own agent
 
         if (me is not None):
-            agentUser = AgentUser.objects.filter(user=self.user).first()
-            if agentUser is None:
-                raise PermissionDenied("Cannot find requested user")
-            return agentUser.agent
+            self._load_own_agent()
 
     # load agents list
 
@@ -56,6 +59,6 @@ class Query(graphene.AbstractType):
     # (this gives the projects, collectives, groups that the user agent is any kind of member of)
 
     def resolve_my_context_agents(self, args, context, info):
-        my_agent = self.resolve_agent(args)
+        my_agent = self._load_own_agent()
         return my_agent.is_member_of()
     

--- a/valuenetwork/api/schemas/Agent.py
+++ b/valuenetwork/api/schemas/Agent.py
@@ -16,12 +16,14 @@ from valuenetwork.api.schemas.helpers import *
 
 # bind Django models to Graphene types
 
+
 class Agent(DjangoObjectType):
     class Meta:
         model = EconomicAgent
-        only_fields =  ('id', 'name', 'nick', 'url', 'is_context')
+        only_fields = ('id', 'name', 'nick', 'url', 'is_context')
 
 # define public query API
+
 
 class Query(graphene.AbstractType):
 
@@ -31,8 +33,9 @@ class Query(graphene.AbstractType):
                            me=graphene.Boolean())
 
     all_agents = graphene.List(Agent)
-    
-    my_context_agents = graphene.List(Agent)
+
+    my_context_agents = graphene.List(Agent,
+                                      me=graphene.Boolean())
 
     # load single agents
 
@@ -55,10 +58,10 @@ class Query(graphene.AbstractType):
     def resolve_all_agents(self, args, context, info):
         return EconomicAgent.objects.all()
 
-    # load context agents that 'me' is related to with 'member' behavior 
-    # (this gives the projects, collectives, groups that the user agent is any kind of member of)
+    # load context agents that 'me' is related to with 'member' behavior
+    # (this gives the projects, collectives, groups that the user agent is any
+    # kind of member of)
 
     def resolve_my_context_agents(self, args, context, info):
         my_agent = self._load_own_agent()
         return my_agent.is_member_of()
-    

--- a/valuenetwork/api/schemas/Agent.py
+++ b/valuenetwork/api/schemas/Agent.py
@@ -64,4 +64,4 @@ class Query(graphene.AbstractType):
 
     def resolve_my_context_agents(self, args, context, info):
         my_agent = self._load_own_agent()
-        return my_agent.is_member_of()
+        return my_agent.member_associations()

--- a/valuenetwork/api/tests.py
+++ b/valuenetwork/api/tests.py
@@ -1,12 +1,12 @@
 from django.test import TestCase
 
 
-class EconomicAgentSchemaTest(TestCase):
+class AgentSchemaTest(TestCase):
     @classmethod
     def setUpClass(cls):
         import os
         os.environ['DJANGO_SETTINGS_MODULE'] = 'valuenetwork.settings'
-        super(EconomicAgentSchemaTest, cls).setUpClass()
+        super(AgentSchemaTest, cls).setUpClass()
         import django
         django.setup()
 


### PR DESCRIPTION
Please don't merge without taking a really good look!  And if you can wait for the new method to get context agents for the user, you might want to wait until I can test it. 

Made EconomicAgent into Agent.  This is to map to ValueFlows.  [edit: You will probably have to change the corresponding code on the client.]

Added method to get context agents for user agent as member.  I didn't add a test, but the underlying method is tested in valueaccounting.models.  Existing schema tests do still run. 

Took out the secondary gets by nick and name for user - agent.  I don't think the base OCP app will work if there isn't a FK connection between user and agent.  If you disagree, let's discuss, and I'm totally willing to put that code back.

Biggest question so far:  I'm not sure how to change the naming, and occasionally the class structure, to map to VF, from within the schema stuff.  (This is related to not knowing how if an object (like an agent) is returned, how the graphql interprets it to the client.)  Maybe I have to build that different structure in the api models and just move all the data over???

Also, I'd like to figure out how to test the new schema code in the python shell, so it gets better tested than we can realistically write in the test.py.

[Edit: Those questions are mostly for me to research, not for someone to answer unless you know without research.]