### PR TITLE
fix process urls in notification emails

### DIFF
--- a/valuenetwork/valueaccounting/models.py
+++ b/valuenetwork/valueaccounting/models.py
@@ -15,6 +15,7 @@ from django.template.defaultfilters import slugify
 import json as simplejson
 from django.db.models.functions import Lower
 from django.conf import settings
+from django.urls import reverse
 
 from faircoin import utils as faircoin_utils
 from easy_thumbnails.fields import ThumbnailerImageField
@@ -6339,6 +6340,12 @@ class Process(models.Model):
     def get_absolute_url(self):
         return ('process_details', (),
             { 'process_id': str(self.id),})
+                
+    def get_notification_url(self):
+        if 'work.apps.WorkAppConfig' in settings.INSTALLED_APPS:
+            return reverse('process_logging', kwargs={ 'process_id': str(self.id)})
+        else:
+            return reverse('process_details', kwargs={ 'process_id': str(self.id)})
 
     def save(self, *args, **kwargs):
         pt_name = ""

--- a/valuenetwork/valueaccounting/templates/pinax/notifications/valnet_help_wanted/full.txt
+++ b/valuenetwork/valueaccounting/templates/pinax/notifications/valnet_help_wanted/full.txt
@@ -10,4 +10,4 @@ for Process: {{ process }}
 This message has most likely been sent to other individuals. 
 
 You can see the process here:{% endblocktrans %}
-https://{{ current_site }}{{ process.get_absolute_url }}
+https://{{ current_site }}{{ process.get_notification_url }}

--- a/valuenetwork/valueaccounting/templates/pinax/notifications/valnet_join_task/full.txt
+++ b/valuenetwork/valueaccounting/templates/pinax/notifications/valnet_join_task/full.txt
@@ -10,4 +10,4 @@ for Process: {{ process }}
 This message has been sent to you because you are working on this task or have assigned yourself to this task.
 
 You can see the process here:{% endblocktrans %}
-https://{{ current_site }}{{ process.get_absolute_url }}
+https://{{ current_site }}{{ process.get_notification_url }}

--- a/valuenetwork/valueaccounting/templates/pinax/notifications/valnet_new_task/full.txt
+++ b/valuenetwork/valueaccounting/templates/pinax/notifications/valnet_new_task/full.txt
@@ -12,4 +12,4 @@ IF you want to take the task, you can, but if not others will take it.
 First-come-first-served. 
 
 You can see the process here:{% endblocktrans %}
-https://{{ current_site }}{{ process.get_absolute_url }}
+https://{{ current_site }}{{ process.get_notification_url }}


### PR DESCRIPTION
to go to work pages instead of accounting
this fixes https://github.com/FreedomCoop/valuenetwork/issues/354