### PR TITLE
peg file versions for graphene, now it compiles (but api does not run)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,8 @@ django-simple-captcha
 django-mptt
 django-fobi==0.12.2
 pytz
-graphene-django>=1.0
+graphene==1.4
+graphene-django==1.3
 PyJWT
 six
 selenium


### PR DESCRIPTION
@bum2 here is the fix for the error you found locally when testing the api-extensions merge, thanks to @bhaugen .

When I retested locally, I uninstalled graphene-django and graphene, then ran the requirements.txt using the command you used locally:
`pip install -r requirements.txt --upgrade --trusted-host dist.pinaxproject.com`
I was way out of date locally, and it upgraded a lot of stuff.

Current status, with this fix:  
* It compiles.  
* The valueaccounting tests run.  
* I did a spot test in the work app and it looks OK.  
* Nothing works any more in the api, but then the api wasn't there before in master, so that doesn't impact anyone.

So, I did this PR in case you want or need to merge it into master so that it will compile.  If you need to deploy master in production, I think this should work.  But it was really good you tested locally, and if you could do that again first, I think it would be a really good idea.