### PR TITLE
peg graphql-core version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ django-simple-captcha
 django-mptt
 django-fobi==0.12.2
 pytz
+graphql-core==1.1
 graphene==1.4
 graphene-django==1.3
 PyJWT


### PR DESCRIPTION
This fixed the api problem that got created when I updated from requirements.txt.  (Prod is probably OK, still has the older version installed I'm guessing.  Testocp had the older version.)