### PR TITLE
Made all work forms show all members (including groups) as from_agent.

### DIFF
--- a/valuenetwork/valueaccounting/forms.py
+++ b/valuenetwork/valueaccounting/forms.py
@@ -1548,7 +1548,7 @@ class InputEventForm(forms.ModelForm):
 class InputEventAgentForm(forms.ModelForm):
     from_agent = forms.ModelChoiceField(
         required=True,
-        queryset=EconomicAgent.objects.individuals(),
+        queryset=EconomicAgent.objects.all(),
         label="Work done by",
         empty_label=None,
         widget=forms.Select(
@@ -1568,10 +1568,12 @@ class InputEventAgentForm(forms.ModelForm):
         model = EconomicEvent
         fields = ('event_date', 'from_agent', 'quantity', 'is_contribution', 'description', )
 
-    def __init__(self, qty_help=None, *args, **kwargs):
+    def __init__(self, qty_help=None, context_agent=None, *args, **kwargs):
         super(InputEventAgentForm, self).__init__(*args, **kwargs)
         if qty_help:
             self.fields["quantity"].help_text = qty_help
+        if context_agent:
+            self.fields["from_agent"].queryset = context_agent.all_members()
 
 #may be obsolete
 class WorkContributionChangeForm(forms.ModelForm):

--- a/valuenetwork/valueaccounting/models.py
+++ b/valuenetwork/valueaccounting/models.py
@@ -10095,9 +10095,9 @@ class Commitment(models.Model):
                 unit_string = unit.name
             qty_help = " ".join(["unit:", unit_string, ", up to 2 decimal places"])
         if init:
-            return InputEventAgentForm(qty_help=qty_help, prefix=prefix, initial=init, data=data)
+            return InputEventAgentForm(qty_help=qty_help, context_agent=self.context_agent, prefix=prefix, initial=init, data=data)
         else:
-            return InputEventAgentForm(qty_help=qty_help, prefix=prefix, data=data)
+            return InputEventAgentForm(qty_help=qty_help, context_agent=self.context_agent, prefix=prefix, data=data)
 
     def consumption_event_form(self):
         from valuenetwork.valueaccounting.forms import InputEventForm
@@ -12501,7 +12501,7 @@ class EconomicEvent(models.Model):
         if unit:
             qty_help = " ".join(["unit:", unit.abbrev, ", up to 2 decimal places"])
         from valuenetwork.valueaccounting.forms import InputEventAgentForm
-        return InputEventAgentForm(qty_help=qty_help, instance=self, prefix=prefix, data=data)
+        return InputEventAgentForm(qty_help=qty_help, context_agent=self.context_agent, instance=self, prefix=prefix, data=data)
 
     def change_form_old(self, data=None):
         from valuenetwork.valueaccounting.forms import TimeEventForm, InputEventForm

--- a/valuenetwork/valueaccounting/views.py
+++ b/valuenetwork/valueaccounting/views.py
@@ -8677,9 +8677,10 @@ def change_work_event(request, event_id):
     event = get_object_or_404(EconomicEvent, id=event_id)
     commitment = event.commitment
     process = event.process
+    context_agent = event.context_agent
     if request.method == "POST":
         prefix = event.form_prefix()
-        form = InputEventAgentForm(instance=event, prefix=prefix, data=request.POST)
+        form = InputEventAgentForm(context_agent=context_agent, instance=event, prefix=prefix, data=request.POST)
         if form.is_valid():
             data = form.cleaned_data
             form.save()


### PR DESCRIPTION
This is for the OCW group, so that collectives can log work.  I assume there is no impact on BotC because I don't think they are logging work, but mention it just in case.  (All tests in the valueaccounting test suite run OK.)