### PR TITLE
Make email notifications opt-in - fix 433 when deployed

### DIFF
--- a/optin.py
+++ b/optin.py
@@ -1,0 +1,28 @@
+import os, sys
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "valuenetwork.settings")
+
+import django
+django.setup()
+
+    
+from pinax.notifications import models as notification
+
+nts = notification.NoticeType.objects.all()
+
+for nt in nts:
+    nt.default = 0
+    nt.save()
+    
+print ""
+print "changed ", nts.count(), "NoticeType defaults to 0."
+
+nsets = notification.NoticeSetting.objects.all()
+
+for nset in nsets:
+    nset.send = False
+    nset.save()
+
+print "changed ", nsets.count(), "NoticeSetting send flags to False."
+print "This turns off all email notifications."
+

--- a/valuenetwork/settings.py
+++ b/valuenetwork/settings.py
@@ -244,6 +244,9 @@ PAYMENT_GATEWAYS = {} # Fill the object in local_settings.py with custom gateway
 
 
 PINAX_NOTIFICATIONS_QUEUE_ALL = True
+PINAX_NOTIFICATIONS_BACKENDS = [
+        ("email", "pinax.notifications.backends.email.EmailBackend", 1),
+    ]
 
 THUMBNAIL_DEBUG = True
 

--- a/valuenetwork/valueaccounting/signals.py
+++ b/valuenetwork/valueaccounting/signals.py
@@ -4,19 +4,19 @@ from django.utils.translation import ugettext_noop as _
 def create_notice_types(sender, **kwargs):
     if "pinax.notifications" in settings.INSTALLED_APPS:
         from pinax.notifications import models as notification
-        notification.NoticeType.create("valnet_join_task", _("Join Task"), _("a colleaque wants to help with this task"), default=2)
-        notification.NoticeType.create("valnet_help_wanted", _("Help Wanted"), _("a colleague requests help that fits your skills"), default=2)
-        notification.NoticeType.create("valnet_new_task", _("New Task"), _("a new task was posted that fits your skills"), default=2)
-        notification.NoticeType.create("valnet_new_todo", _("New Todo"), _("a new todo was posted that is assigned to you"), default=2)
-        notification.NoticeType.create("valnet_deleted_todo", _("Deleted Todo"), _("a todo that was assigned to you has been deleted"), default=2)
-        notification.NoticeType.create("valnet_distribution", _("New Distribution"), _("you have received a new income distribution"), default=2)
-        notification.NoticeType.create("valnet_payout_request", _("Payout Request"), _("you have received a new payout request"), default=2)
-        notification.NoticeType.create("work_membership_request", _("Freedom Coop Membership Request"), _("we have received a new membership request"), default=2)
-        notification.NoticeType.create("work_join_request", _("Project Join Request"), _("we have received a new join request"), default=2)
-        notification.NoticeType.create("work_new_account", _("Project New OCP Account"), _("a new OCP account details"), default=2)
-        notification.NoticeType.create("comment_membership_request", _("Comment in Freedom Coop Membership Request"), _("we have received a new comment in a membership request"), default=2)
-        notification.NoticeType.create("comment_join_request", _("Comment in Project Join Request"), _("we have received a new comment in a join request"), default=2)
-        notification.NoticeType.create("work_skill_suggestion", _("Skill suggestion"), _("we have received a new skill suggestion"), default=2)
+        notification.NoticeType.create("valnet_join_task", _("Join Task"), _("a colleaque wants to help with this task"), default=0)
+        notification.NoticeType.create("valnet_help_wanted", _("Help Wanted"), _("a colleague requests help that fits your skills"), default=0)
+        notification.NoticeType.create("valnet_new_task", _("New Task"), _("a new task was posted that fits your skills"), default=0)
+        notification.NoticeType.create("valnet_new_todo", _("New Todo"), _("a new todo was posted that is assigned to you"), default=0)
+        notification.NoticeType.create("valnet_deleted_todo", _("Deleted Todo"), _("a todo that was assigned to you has been deleted"), default=0)
+        notification.NoticeType.create("valnet_distribution", _("New Distribution"), _("you have received a new income distribution"), default=0)
+        notification.NoticeType.create("valnet_payout_request", _("Payout Request"), _("you have received a new payout request"), default=0)
+        notification.NoticeType.create("work_membership_request", _("Freedom Coop Membership Request"), _("we have received a new membership request"), default=0)
+        notification.NoticeType.create("work_join_request", _("Project Join Request"), _("we have received a new join request"), default=0)
+        notification.NoticeType.create("work_new_account", _("Project New OCP Account"), _("a new OCP account details"), default=0)
+        notification.NoticeType.create("comment_membership_request", _("Comment in Freedom Coop Membership Request"), _("we have received a new comment in a membership request"), default=0)
+        notification.NoticeType.create("comment_join_request", _("Comment in Project Join Request"), _("we have received a new comment in a join request"), default=0)
+        notification.NoticeType.create("work_skill_suggestion", _("Skill suggestion"), _("we have received a new skill suggestion"), default=0)
         print "created valueaccounting notice types"
     else:
         print "Skipping creation of valueaccounting NoticeTypes as notification app not found"


### PR DESCRIPTION
Once merged and deployed, this will turn off all email notifications until users change their settings to request them. This will complete https://github.com/FreedomCoop/valuenetwork/issues/433

It includes code changes to settings.py and signals.py *plus* 

**IMPORTANT:**
This PR includes a python script called optin.py which must be run before the emails will really be turned off.
The script is in the first valuenetwork directory.  From the command line on the server, in that directory, do
```
python optin.py
```
Let me know if you run into any problems, but I have tested everything thoroughly. On the server, you might need to say something like 
```
python2.7 optin.py
```