### PR TITLE
Pass in a mock :context object so AuthedMutation doesn't crash in tests.

### DIFF
--- a/valuenetwork/api/schemas/Process.py
+++ b/valuenetwork/api/schemas/Process.py
@@ -52,7 +52,6 @@ class CreateProcess(AuthedMutation):
 
     @classmethod
     def mutate(cls, root, args, context, info):
-        #import pdb; pdb.set_trace()
         name = args.get('name')
         planned_start = args.get('planned_start')
         planned_duration = args.get('planned_duration')

--- a/valuenetwork/api/tests.py
+++ b/valuenetwork/api/tests.py
@@ -11,6 +11,9 @@ logger = logging.getLogger("graphql.execution.executor").addHandler(logging.Null
 # comment out the line above and uncomment the one below:
 #logging.basicConfig()
 
+class MockContext:
+    user = None
+
 class APITest(TestCase):
     @classmethod
     def setUpClass(cls):
@@ -770,78 +773,77 @@ class APITest(TestCase):
         self.assertEqual(process['processClassifiedAs']['name'], 'pt1')
 
 
-#    def test_create_update_delete_process(self):
-#        result = schema.execute('''
-#                mutation {
-#                  createToken(username: "testUser11222", password: "123456") {
-#                    token
-#                  }
-#                }
-#                ''')
-#        call_result = result.data['createToken']
-#        token = call_result['token']
-#        test_agent = EconomicAgent.objects.get(name="testUser11222")
+    def test_create_update_delete_process(self):
+        result = schema.execute('''
+                mutation {
+                  createToken(username: "testUser11222", password: "123456") {
+                    token
+                  }
+                }
+                ''', context_value=MockContext())
+        call_result = result.data['createToken']
+        token = call_result['token']
+        test_agent = EconomicAgent.objects.get(name="testUser11222")
 
-#        result1 = schema.execute('''
-#                mutation {
-#                  createProcess(token: "''' + token + '''", name: "Make something cool", plannedStart: "2017-07-07", plannedDuration: 7, scopeId: 2) {
-#                    process {
-#                        name
-#                        scope {
-#                            name
-#                        }
-#                        isFinished
-#                        plannedStart
-#                        plannedDuration
-#                    }
-#                  }
-#                }
-#                ''')
-#        #import pdb; pdb.set_trace()
-#        self.assertEqual(result1.data['createProcess']['process']['name'], "Make something cool")
-#        self.assertEqual(result1.data['createProcess']['process']['scope']['name'], "org1")
-#        self.assertEqual(result1.data['createProcess']['process']['isFinished'], False)
-#        self.assertEqual(result1.data['createProcess']['process']['plannedStart'], "2017-07-07")
-#        self.assertEqual(result1.data['createProcess']['process']['plannedDuration'], "7 days, 0:00:00")
+        result1 = schema.execute('''
+                mutation {
+                  createProcess(token: "''' + token + '''", name: "Make something cool", plannedStart: "2017-07-07", plannedDuration: 7, scopeId: 2) {
+                    process {
+                        name
+                        scope {
+                            name
+                        }
+                        isFinished
+                        plannedStart
+                        plannedDuration
+                    }
+                  }
+                }
+                ''', context_value=MockContext())
+        self.assertEqual(result1.data['createProcess']['process']['name'], "Make something cool")
+        self.assertEqual(result1.data['createProcess']['process']['scope']['name'], "org1")
+        self.assertEqual(result1.data['createProcess']['process']['isFinished'], False)
+        self.assertEqual(result1.data['createProcess']['process']['plannedStart'], "2017-07-07")
+        self.assertEqual(result1.data['createProcess']['process']['plannedDuration'], "7 days, 0:00:00")
 
-#        result2 = schema.execute('''
-#                    mutation {
-#                        updateProcess(token: "''' + token + '''", id: 4, plannedDuration: 10, isFinished: true) {
-#                            process {
-#                                name
-#                                scope {
-#                                    name
-#                                }
-#                                isFinished
-#                                plannedStart
-#                                plannedDuration
-#                            }
-#                        }
-#                    }
-#                    ''')
+        result2 = schema.execute('''
+                    mutation {
+                        updateProcess(token: "''' + token + '''", id: 4, plannedDuration: 10, isFinished: true) {
+                            process {
+                                name
+                                scope {
+                                    name
+                                }
+                                isFinished
+                                plannedStart
+                                plannedDuration
+                            }
+                        }
+                    }
+                    ''', context_value=MockContext())
 
-#        self.assertEqual(result2.data['updateProcess']['process']['name'], "Make something cool")
-#        self.assertEqual(result2.data['updateProcess']['process']['scope']['name'], "org1")
-#        self.assertEqual(result2.data['updateProcess']['process']['isFinished'], True)
-#        self.assertEqual(result2.data['updateProcess']['process']['plannedStart'], "2017-07-07")
-#        self.assertEqual(result2.data['updateProcess']['process']['plannedDuration'], "10 days, 0:00:00")
+        self.assertEqual(result2.data['updateProcess']['process']['name'], "Make something cool")
+        self.assertEqual(result2.data['updateProcess']['process']['scope']['name'], "org1")
+        self.assertEqual(result2.data['updateProcess']['process']['isFinished'], True)
+        self.assertEqual(result2.data['updateProcess']['process']['plannedStart'], "2017-07-07")
+        self.assertEqual(result2.data['updateProcess']['process']['plannedDuration'], "10 days, 0:00:00")
 
-#        result3 = schema.execute('''
-#                    mutation {
-#                        deleteProcess(token: "''' + token + '''", id: 4) {
-#                            process {
-#                                name
-#                            }
-#                        }
-#                    }
-#                    ''')
+        result3 = schema.execute('''
+                    mutation {
+                        deleteProcess(token: "''' + token + '''", id: 4) {
+                            process {
+                                name
+                            }
+                        }
+                    }
+                    ''', context_value=MockContext())
 
-#        proc = None
-#        try:
-#            proc = Process.objects.get(pk=4)
-#        except:
-#            pass
-#        self.assertEqual(proc, None)
+        proc = None
+        try:
+            proc = Process.objects.get(pk=4)
+        except:
+            pass
+        self.assertEqual(proc, None)
 
 
 ######################### SAMPLE QUERIES #####################


### PR DESCRIPTION
Seems like :context is None in tests and was crashing 'context.user = ...' in AuthedMutation.

Fixes #441.