### PR TITLE
Replace MIDDLEWARE_CLASSES with MIDDLEWARE

### DIFF
--- a/account/middleware.py
+++ b/account/middleware.py
@@ -1,10 +1,11 @@
 from django.utils import translation, timezone
 from django.utils.cache import patch_vary_headers
+from django.utils.deprecation import MiddlewareMixin
 
 from account.models import Account
 
 
-class LocaleMiddleware(object):
+class LocaleMiddleware(MiddlewareMixin):
     """
     This is a very simple middleware that parses a request
     and decides what translation object to install in the current
@@ -33,7 +34,7 @@ class LocaleMiddleware(object):
         return response
 
 
-class TimezoneMiddleware(object):
+class TimezoneMiddleware(MiddlewareMixin):
     """
     This middleware sets the timezone used to display dates in
     templates to the user's timezone.

--- a/valuenetwork/login_required_middleware.py
+++ b/valuenetwork/login_required_middleware.py
@@ -1,13 +1,14 @@
 from django.http import HttpResponseRedirect
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.utils.deprecation import MiddlewareMixin
 from re import compile
 
 EXEMPT_URLS = [compile(settings.LOGIN_URL.lstrip('/'))]
 if hasattr(settings, 'LOGIN_EXEMPT_URLS'):
     EXEMPT_URLS += [compile(expr) for expr in settings.LOGIN_EXEMPT_URLS]
 
-class LoginRequiredMiddleware:
+class LoginRequiredMiddleware(MiddlewareMixin):
     """
     Middleware that requires a user to be authenticated to view any page other
     than LOGIN_URL. Exemptions to this requirement can optionally be specified
@@ -20,7 +21,7 @@ class LoginRequiredMiddleware:
     def process_request(self, request):
         assert hasattr(request, 'user'), "The Login Required middleware\
             requires authentication middleware to be installed. Edit your\
-            MIDDLEWARE_CLASSES setting to insert\
+            MIDDLEWARE setting to insert\
             'django.contrib.auth.middleware.AuthenticationMiddleware'. If that doesn't\
             work, ensure your TEMPLATE_CONTEXT_PROCESSORS setting includes\
             'django.core.context_processors.auth'."

--- a/valuenetwork/settings.py
+++ b/valuenetwork/settings.py
@@ -101,7 +101,7 @@ LOGIN_EXEMPT_URLS = [
 PROJECTS_LOGIN = {} # Fill the object in local_settings.py with custom login data by project
 
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     #'django.middleware.locale.LocaleMiddleware',


### PR DESCRIPTION
For now I removed the drepecation with the `django.utils.deprecation.MiddlewareMixin`. In the future `LocaleMiddleware`, `TimezoneMiddleware` and `LoginRequiredMiddleware` can be implemented as new middleware especification with minimal changes.